### PR TITLE
Fix WordPress notice: is_main_query in pre_get_posts

### DIFF
--- a/includes/class-epa-integration.php
+++ b/includes/class-epa-integration.php
@@ -38,7 +38,7 @@ class EPA_Integration {
 	}
 
 	public function pre_get_posts( $query ) {
-		if ( is_admin() && is_main_query() ) {
+		if ( is_admin() && $query->is_main_query() ) {
 			$query->set( 'search_fields', array( 'meta' => '*' ) );
 		}
 	}

--- a/includes/class-epa-integration.php
+++ b/includes/class-epa-integration.php
@@ -13,7 +13,6 @@ class EPA_Integration {
 	 *
 	 */
 	public function setup() {
-
 		// Override the admin integration in ElasticPress
 		add_filter( 'ep_admin_wp_query_integration', array( $this, 'admin_integration' ) );
 
@@ -54,7 +53,7 @@ class EPA_Integration {
 
 		if ( ! $instance ) {
 			$instance = new self();
-			$instance->setup();
+			add_action('plugins_loaded', array($instance, 'setup'), 10);
 		}
 
 		return $instance;


### PR DESCRIPTION
WordPress suggests to use `WP_Query::is_main_query()` instead of
`is_main_query()` if called from pre_get_posts.
See http://codex.wordpress.org/Function_Reference/is_main_query