### PR TITLE
Don't overwrite post title and post content fields with post meta

### DIFF
--- a/includes/class-epa-integration.php
+++ b/includes/class-epa-integration.php
@@ -18,7 +18,7 @@ class EPA_Integration {
 		add_filter( 'ep_admin_wp_query_integration', array( $this, 'admin_integration' ) );
 
 		// Search all available post meta fields
-		add_filter( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
+		add_filter( 'ep_search_fields', array( $this, 'ep_search_fields' ) );
 	}
 
 	/**
@@ -37,10 +37,19 @@ class EPA_Integration {
 		return $integration;
 	}
 
-	public function pre_get_posts( $query ) {
-		if ( is_admin() && $query->is_main_query() ) {
-			$query->set( 'search_fields', array( 'meta' => '*' ) );
+	/**
+	 * Extend our search to include all indexed post meta fields
+	 *
+	 * @param $fields
+	 *
+	 * @return array
+	 */
+	public function ep_search_fields( $fields ) {
+		if ( is_admin()  ) {
+			$fields[] = 'post_meta.*';
 		}
+
+		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the search fields to not overwrite the post_title and post_content fields with meta.

Props @tinkerborg!
